### PR TITLE
feat: 마이페이지 기본 화면

### DIFF
--- a/src/apis/auth/index.ts
+++ b/src/apis/auth/index.ts
@@ -8,6 +8,7 @@ interface PostLoginParams {
 
 interface AuthRepository {
   postLogin: ({ identification, password, category }: PostLoginParams) => Promise<any>;
+  postLogout: ({ token }: { token: string }) => Promise<any>;
 }
 
 const authRepository = (): AuthRepository => {
@@ -17,6 +18,12 @@ const authRepository = (): AuthRepository => {
         identification,
         password,
         category,
+      }),
+    postLogout: async ({ token }) =>
+      await http.delete('/apis/v1/account/tokens', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
       }),
   };
 };

--- a/src/apis/user/getUser.ts
+++ b/src/apis/user/getUser.ts
@@ -10,6 +10,10 @@ interface IRegion {
 export interface UserRes {
   id: number;
   nickname: string;
+  authentication: {
+    company_email: string;
+    account_email: string;
+  };
   activity_area: IRegion;
   dining_area: IRegion;
 }

--- a/src/app/login/hooks/useLogoutMutate.tsx
+++ b/src/app/login/hooks/useLogoutMutate.tsx
@@ -1,0 +1,22 @@
+import authRepository from '@/apis/auth';
+import { queryClient } from '@/lib/react-query/ReactQueryProvider';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+const useLogoutMutate = () => {
+  const { push } = useRouter();
+
+  const { mutate } = useMutation(authRepository().postLogout, {
+    onSuccess: () => {
+      queryClient.removeQueries();
+
+      if (typeof window === undefined) return;
+      (sessionStorage as Storage).removeItem('token');
+      push('/');
+    },
+  });
+
+  return { mutate };
+};
+
+export default useLogoutMutate;

--- a/src/app/mypage/page.styled.ts
+++ b/src/app/mypage/page.styled.ts
@@ -1,0 +1,3 @@
+import styled from 'styled-components';
+
+export const MenuList = styled.div``;

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import CHeader from '@/components/c-header';
+import CMypageMenu from '@/components/c-mypage-menu';
+import CMyPageUserInfo from '@/components/c-mypage-user-info';
+import GNBLayout from '@/components/layout/gnb-layout';
+import useUser from '@/hooks/useUser';
+import * as S from './page.styled';
+
+export default function MyPage() {
+  const { isLoggedIn } = useUser();
+
+  return (
+    <>
+      <CHeader title="마이페이지" isLogo />
+
+      <GNBLayout>
+        {isLoggedIn && <CMyPageUserInfo />}
+
+        <S.MenuList>
+          {isLoggedIn && (
+            <CMypageMenu
+              title="계정"
+              items={[
+                { name: '개인정보 관리', hasArrow: true },
+                { name: '내 리뷰 관리' },
+                { name: '북마크 목록' },
+                { name: '추천 제외 식당 보기' },
+              ]}
+            />
+          )}
+
+          <CMypageMenu
+            title="게시판"
+            items={[{ name: '공지사항' }, { name: '자주 묻는 질문' }, { name: '의견 보내기' }]}
+          />
+
+          <CMypageMenu title="약관 및 정책" items={[{ name: '서비스 이용약관' }, { name: '개인정보 처리 방침' }]} />
+        </S.MenuList>
+      </GNBLayout>
+    </>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,19 @@
 'use client';
 
 import * as S from '@/app/page.styled';
-import HomeIcon from '@/assets/logo/home.svg';
-import MypageIcon from '@/assets/logo/my-page.svg';
-import ReviewIcon from '@/assets/logo/review.svg';
 import { MODAL_TYPES } from '@/components/Modal/GlobalModal';
 import useModal from '@/components/Modal/GlobalModal/hooks/useModal';
 import CHeader from '@/components/c-header';
-import CNavButton from '@/components/c-nav-button';
 import CPickerButton from '@/components/c-pickerButton';
+import GNBLayout from '@/components/layout/gnb-layout';
 import useUser from '@/hooks/useUser';
-import { usePathname, useRouter } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 export default function Home() {
-  const pathName = usePathname();
   const router = useRouter();
   const { openModal, closeModal } = useModal();
 
-  const { isLoggedIn, hasActivityArea } = useUser();
+  const { isLoggedIn } = useUser();
 
   const loginInfoModal = () => {
     openModal(MODAL_TYPES.dialog, {
@@ -31,26 +27,6 @@ export default function Home() {
     });
   };
 
-  const needRegisterActivityAreaModal = () => {
-    openModal(MODAL_TYPES.dialog, {
-      title: '활동 지역 등록 안내',
-      message: '활동 지역을 등록한 회원만\n리뷰 등록이 가능해요.',
-      handleConfirm: () => router.push('/register-review/region-setting'),
-      handleClose: () => closeModal(MODAL_TYPES.dialog),
-      cancelText: '취소',
-      confirmText: '등록하기',
-      needClose: true,
-    });
-  };
-
-  const onReviewClick = () => {
-    if (!isLoggedIn) return loginInfoModal();
-
-    if (!hasActivityArea) return needRegisterActivityAreaModal();
-
-    router.push('/register-review/restaurant');
-  };
-
   const onRestaurantClick = () => {
     if (!isLoggedIn) return loginInfoModal();
 
@@ -60,32 +36,24 @@ export default function Home() {
   return (
     <>
       <CHeader title="맛셔너리" isLogo />
-      <S.MainContent>
-        <CPickerButton
-          title={'메뉴 고르기'}
-          desc={'오늘은 어떤 음식을 먹을까?'}
-          subject={'menu'}
-          clickEvent={() => router.push('select-menu')}
-        />
 
-        <CPickerButton
-          title={'식당 고르기'}
-          desc={'오늘은 어떤 식당에 가볼까?'}
-          subject={'restaurant'}
-          clickEvent={onRestaurantClick}
-        />
-      </S.MainContent>
+      <GNBLayout>
+        <S.MainContent>
+          <CPickerButton
+            title={'메뉴 고르기'}
+            desc={'오늘은 어떤 음식을 먹을까?'}
+            subject={'menu'}
+            clickEvent={() => router.push('select-menu')}
+          />
 
-      <S.NavContainer>
-        <CNavButton title="리뷰" icon={<ReviewIcon />} isActive={false} clickEvent={onReviewClick} />
-        <CNavButton title="홈" icon={<HomeIcon />} isActive={pathName === '/'} />
-        <CNavButton
-          title="마이페이지"
-          icon={<MypageIcon />}
-          isActive={false}
-          clickEvent={() => router.push('/ready')}
-        />
-      </S.NavContainer>
+          <CPickerButton
+            title={'식당 고르기'}
+            desc={'오늘은 어떤 식당에 가볼까?'}
+            subject={'restaurant'}
+            clickEvent={onRestaurantClick}
+          />
+        </S.MainContent>
+      </GNBLayout>
     </>
   );
 }

--- a/src/components/GNB/index.tsx
+++ b/src/components/GNB/index.tsx
@@ -1,0 +1,57 @@
+import * as S from '@/app/page.styled';
+import HomeIcon from '@/assets/logo/home.svg';
+import MypageIcon from '@/assets/logo/my-page.svg';
+import ReviewIcon from '@/assets/logo/review.svg';
+import useUser from '@/hooks/useUser';
+import { usePathname, useRouter } from 'next/navigation';
+import { MODAL_TYPES } from '../Modal/GlobalModal';
+import useModal from '../Modal/GlobalModal/hooks/useModal';
+import CNavButton from '../c-nav-button';
+
+export default function GNB() {
+  const pathName = usePathname();
+  const router = useRouter();
+  const { openModal, closeModal } = useModal();
+
+  const { isLoggedIn, hasActivityArea } = useUser();
+
+  const onReviewClick = () => {
+    if (!isLoggedIn) return loginInfoModal();
+
+    if (!hasActivityArea) return needRegisterActivityAreaModal();
+
+    router.push('/register-review/restaurant');
+  };
+
+  const loginInfoModal = () => {
+    openModal(MODAL_TYPES.dialog, {
+      title: '로그인 안내',
+      message: '내 주변의 식당을 고르기 위해\n로그인이 필요해요.',
+      handleConfirm: () => router.push('/login'),
+      handleClose: () => closeModal(MODAL_TYPES.dialog),
+      cancelText: '취소',
+      confirmText: '로그인 하기',
+      needClose: true,
+    });
+  };
+
+  const needRegisterActivityAreaModal = () => {
+    openModal(MODAL_TYPES.dialog, {
+      title: '활동 지역 등록 안내',
+      message: '활동 지역을 등록한 회원만\n리뷰 등록이 가능해요.',
+      handleConfirm: () => router.push('/register-review/region-setting'),
+      handleClose: () => closeModal(MODAL_TYPES.dialog),
+      cancelText: '취소',
+      confirmText: '등록하기',
+      needClose: true,
+    });
+  };
+
+  return (
+    <S.NavContainer>
+      <CNavButton title="리뷰" icon={<ReviewIcon />} isActive={false} clickEvent={onReviewClick} />
+      <CNavButton title="홈" icon={<HomeIcon />} isActive={pathName === '/'} clickEvent={() => router.push('/')} />
+      <CNavButton title="마이페이지" icon={<MypageIcon />} isActive={false} clickEvent={() => router.push('/mypage')} />
+    </S.NavContainer>
+  );
+}

--- a/src/components/GNB/page.styled.ts
+++ b/src/components/GNB/page.styled.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const NavContainer = styled.div`
+  position: fixed;
+  display: flex;
+  max-width: 360px;
+  width: 100%;
+  bottom: 0;
+
+  & > button {
+    flex-grow: 1;
+  }
+
+  @media screen and (max-width: 768px) {
+    max-width: 100%;
+  }
+`;

--- a/src/components/Modal/DialogModal/index.tsx
+++ b/src/components/Modal/DialogModal/index.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { ReactNode, useEffect, useState } from 'react';
 import * as S from './page.styled';
 
 export interface DialogModalProps {
   title: string;
   message?: string;
+  elementMessage?: ReactNode;
   cancelText?: string;
   confirmText?: string;
   handleClose?: (...arg: any[]) => any;
@@ -14,6 +15,7 @@ export interface DialogModalProps {
 export default function DialogModal({
   title,
   message,
+  elementMessage,
   cancelText,
   confirmText = '확인',
   handleClose,
@@ -53,7 +55,13 @@ export default function DialogModal({
       <S.Container $visible={animate}>
         <S.TextContainer>
           <S.Title>{title}</S.Title>
-          {message && <S.Message>{message}</S.Message>}
+
+          {(message || elementMessage) && (
+            <S.MessageContainer>
+              {message && <S.Message>{message}</S.Message>}
+              {elementMessage ?? null}
+            </S.MessageContainer>
+          )}
         </S.TextContainer>
 
         <S.ButtonContainer>

--- a/src/components/Modal/DialogModal/page.styled.ts
+++ b/src/components/Modal/DialogModal/page.styled.ts
@@ -78,8 +78,11 @@ export const Title = styled.div`
   word-break: keep-all;
 `;
 
-export const Message = styled.p`
+export const MessageContainer = styled.div`
   padding: 8px 24px;
+`;
+
+export const Message = styled.p`
   font-size: 14px;
   font-style: normal;
   font-weight: 400;

--- a/src/components/c-mypage-menu/index.tsx
+++ b/src/components/c-mypage-menu/index.tsx
@@ -1,0 +1,36 @@
+import { useRouter } from 'next/navigation';
+import * as S from './page.styled';
+
+interface Props {
+  title: string;
+  items: {
+    name: string;
+    hasArrow?: boolean;
+    pathname?: string;
+  }[];
+}
+
+export default function CMypageMenu({ title, items }: Props) {
+  const router = useRouter();
+
+  return (
+    <S.Menu>
+      <S.MenuTitle>{title}</S.MenuTitle>
+
+      {items?.map((d, i) => (
+        <S.MenuItem
+          key={i}
+          onClick={() => {
+            if (!d?.pathname) return;
+
+            router.push(d.pathname);
+          }}
+        >
+          <span>{d.name}</span>
+
+          {d?.hasArrow && <span>{'>'}</span>}
+        </S.MenuItem>
+      ))}
+    </S.Menu>
+  );
+}

--- a/src/components/c-mypage-menu/page.styled.ts
+++ b/src/components/c-mypage-menu/page.styled.ts
@@ -1,0 +1,31 @@
+import styled from 'styled-components';
+
+export const Menu = styled.div`
+  padding-top: 24px;
+  width: 100%;
+`;
+
+export const MenuTitle = styled.div`
+  padding: 6px 20px;
+  color: ${({ theme }) => theme.colors.neutral.bg30};
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 12px */
+`;
+
+export const MenuItem = styled.div`
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 17px 24px;
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 14px */
+
+  &:last-child {
+    border-bottom: 1px solid ${({ theme }) => theme.colors.neutral.bg20};
+  }
+`;

--- a/src/components/c-mypage-user-info/index.tsx
+++ b/src/components/c-mypage-user-info/index.tsx
@@ -1,0 +1,72 @@
+import useLogoutMutate from '@/app/login/hooks/useLogoutMutate';
+import useUser from '@/hooks/useUser';
+import { MODAL_TYPES } from '../Modal/GlobalModal';
+import useModal from '../Modal/GlobalModal/hooks/useModal';
+import * as S from './page.styeld';
+
+export default function CMyPageUserInfo() {
+  const { data, token } = useUser();
+  const { openModal, closeModal } = useModal();
+  const { mutate: logoutMutate } = useLogoutMutate();
+
+  const logoutModal = () => {
+    openModal(MODAL_TYPES.dialog, {
+      title: '로그아웃 하시겠습니까?',
+      cancelText: '취소',
+      needClose: true,
+      handleClose: () => closeModal(MODAL_TYPES.dialog),
+      handleConfirm: () => {
+        if (token) logoutMutate({ token });
+      },
+    });
+  };
+
+  const areaModal = () => {
+    openModal(MODAL_TYPES.dialog, {
+      title: '지역 설정 안내',
+      elementMessage: (
+        <S.QuestionModalLists>
+          <S.QuestionModalList>
+            식사 지역 : 식당 추첨 시 기준 위치로 사용되며, 설정한 식사 지역으로부터 700m 이내의 식당을 추천합니다.
+          </S.QuestionModalList>
+
+          <S.QuestionModalList>
+            활동 지역 : 리뷰 작성 시 기준 위치로 사용되며, 활동 지역으로부터 1km 이내의 식당에 한해 리뷰 작성이
+            가능합니다.
+          </S.QuestionModalList>
+        </S.QuestionModalLists>
+      ),
+      handleConfirm: () => closeModal(MODAL_TYPES.dialog),
+    });
+  };
+
+  return (
+    <S.UserInfoContainer>
+      <S.SpaceBetween>
+        <S.Nickname>{data?.nickname}</S.Nickname>
+
+        <S.LogoutBtn onClick={logoutModal}>로그아웃 {'>'}</S.LogoutBtn>
+      </S.SpaceBetween>
+
+      <S.Email>{data?.authentication?.account_email}</S.Email>
+
+      <S.AreaContainer>
+        <S.AreaBox>
+          <S.AreaBoxLValue>식사 지역</S.AreaBoxLValue>
+
+          <S.AreaBoxLValue></S.AreaBoxLValue>
+        </S.AreaBox>
+
+        <S.AreaBox>
+          <S.AreaBoxLValue>활동 지역</S.AreaBoxLValue>
+
+          <S.AreaBoxLValue></S.AreaBoxLValue>
+        </S.AreaBox>
+      </S.AreaContainer>
+
+      <S.QuestionContainer>
+        <S.Question onClick={areaModal}>식사 지역과 활동 지역은 어떤 차이인가요?</S.Question>
+      </S.QuestionContainer>
+    </S.UserInfoContainer>
+  );
+}

--- a/src/components/c-mypage-user-info/page.styeld.ts
+++ b/src/components/c-mypage-user-info/page.styeld.ts
@@ -1,0 +1,97 @@
+import styled from 'styled-components';
+
+export const UserInfoContainer = styled.div`
+  width: 100%;
+  padding: 40px 20px 10px;
+`;
+
+export const SpaceBetween = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+`;
+
+export const Nickname = styled.span`
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 20px */
+`;
+
+export const LogoutBtn = styled.button`
+  color: ${({ theme }) => theme.colors.neutral.bg40};
+  font-size: 14px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 14px */
+`;
+
+export const Email = styled.div`
+  color: ${({ theme }) => theme.colors.neutral.bg40};
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 12px */
+  margin-bottom: 20px;
+`;
+
+export const AreaContainer = styled.div`
+  display: flex;
+  margin-bottom: 14px;
+`;
+
+export const AreaBox = styled.div`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.neutral.bg10};
+  background-color: ${({ theme }) => theme.colors.neutral.bg05};
+  padding: 14px 12px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const AreaBoxLabel = styled.span`
+  color: ${({ theme }) => theme.colors.neutral.bg30};
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 12px */
+`;
+
+export const AreaBoxLValue = styled(AreaBoxLabel)`
+  color: ${({ theme }) => theme.colors.neutral.bg80};
+`;
+
+export const QuestionContainer = styled.div`
+  width: 100%;
+  text-align: center;
+`;
+
+export const Question = styled.span`
+  cursor: pointer;
+  color: ${({ theme }) => theme.colors.neutral.bg20};
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%; /* 12px */
+  text-decoration-line: underline;
+`;
+
+export const QuestionModalLists = styled.ul`
+  list-style: disc;
+  list-style-position: outside;
+  padding-left: 1em;
+`;
+
+export const QuestionModalList = styled.li`
+  color: ${({ theme }) => theme.colors.neutral.bg40};
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 160%; /* 19.2px */
+
+  &:last-child {
+    margin-top: 10px;
+  }
+`;

--- a/src/components/layout/gnb-layout/index.tsx
+++ b/src/components/layout/gnb-layout/index.tsx
@@ -1,0 +1,16 @@
+import GNB from '@/components/GNB';
+import * as S from './page.styled';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+export default function GNBLayout({ children }: Props) {
+  return (
+    <S.Wrapper>
+      {children}
+
+      <GNB />
+    </S.Wrapper>
+  );
+}

--- a/src/components/layout/gnb-layout/page.styled.ts
+++ b/src/components/layout/gnb-layout/page.styled.ts
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Wrapper = styled.div`
+  padding-bottom: 60px;
+`;


### PR DESCRIPTION
## 📑 제목
마이페이지 기본 화면

## 📎 관련 이슈
resolve #TAS-55
  
## 💬 작업 내용
<img width="360" alt="스크린샷 2023-12-02 오후 8 21 02" src="https://github.com/tastetionary/tastetionary-client/assets/66504333/e6ff76d7-254b-4966-8310-95b252f4ab16">

- 마이페이지 기본 화면 추가 (활동 지역, 식사 지역은 기획에서 확정되면 추가 예정)
- 로그아웃 기능 추가
- GNB 컴포넌트 분리
 
## 🚧 PR 특이 사항
- 로그아웃은 화면이 없는데, 불편해서 우선 기능 붙혀놨습니다. 화면이 나오면 수정하겠습니다.

## 🕰 실제 소요 시간
2h