### PR TITLE
[TAS-42] fix: 식당 추첨 결과 > 리뷰 키워드 중복 제거

### DIFF
--- a/src/app/select-restaurant/result/page.tsx
+++ b/src/app/select-restaurant/result/page.tsx
@@ -29,6 +29,8 @@ export default function SelectRestaurantResult() {
   const lng = result?.longitude;
   const review = result?.review;
 
+  const uniqueReviewKeyword = review?.keywords?.filter((k, i) => review?.keywords.indexOf(k) === i);
+
   useEffect(() => {
     const getImage = async () => {
       const res = await axios.get(`/search-image-api?query=${restaurant}`, {
@@ -170,7 +172,7 @@ export default function SelectRestaurantResult() {
 
       <CSelectSection title="리뷰 키워드">
         <S.ReviewKeywordContainer>
-          {review?.keywords?.map((k, i) => (
+          {uniqueReviewKeyword?.map((k, i) => (
             <KeywordBtn as="div" key={i}>
               {k}
             </KeywordBtn>


### PR DESCRIPTION
## 📑 제목
식당 추첨 결과 > 리뷰 키워드 중복 제거

## 📎 관련 이슈
resolve #TAS-42
  
## 💬 작업 내용
- 식당 리뷰 배열 중복 제거
 
## 🚧 PR 특이 사항
- 없습니다

## 🕰 실제 소요 시간
0.1h