### PR TITLE
[TAS-124] fix : hydration error 및 console 에러 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       <head>
         <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
       </head>
-      <body className={`${subFont.variable} ${mainFont.variable}`}>
+      <body className={`${subFont.variable} ${mainFont.variable}`} suppressHydrationWarning>
         <StyledComponentsRegistry>
           <RecoilRootWrapper>
             <StyledComponentsWrapper>{children}</StyledComponentsWrapper>

--- a/src/components/google-analytics/index.tsx
+++ b/src/components/google-analytics/index.tsx
@@ -7,14 +7,14 @@ export default function GoogleAnalytics() {
 
   return (
     <>
-      <Script src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
+      <Script async src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`} />
       <Script id="google-analytics">
         {`
           window.dataLayer = window.dataLayer || [];
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
  
-          gtag('config', ${GA_MEASUREMENT_ID},{
+          gtag('config', '${GA_MEASUREMENT_ID}',{
              page_path: window.location.pathname
           });
         `}


### PR DESCRIPTION
## 📑 제목
<img width="668" alt="스크린샷 2024-01-04 오후 9 02 57" src="https://github.com/tastetionary/tastetionary-client/assets/76891694/776d92a6-9435-47a1-a877-20264cc6db64">
<img width="698" alt="스크린샷 2024-01-04 오후 9 10 50" src="https://github.com/tastetionary/tastetionary-client/assets/76891694/2a73949e-f08a-4f8a-a28b-06e82549712e">


## 📎 관련 이슈
resolve #TAS-124
  
## 💬 작업 내용
- console에 에러나는 부분을 제거하는 작업을 진행했습니다. 
- G is not defined의 경우에는 GA 부분을 환경변수로 설정해서 Script 태그안에 뿌릴때 해당 부분을 문자열로 인식하지 못하는 이슈였습니다. 
- cz-shortcut 부분은 브라우저 익스텐션과 연관된 에러였습니다. 저 같은 경우 ColorZilla가 깔려있어서 에러가 났던것으로 파악해서 suppressHydrationWarning을 통해 제거하였습니다.
 
## 🚧 PR 특이 사항
없습니다.

## 🕰 실제 소요 시간
1h