### PR TITLE
식당 추천, 리뷰 작성 페이지의 횡스크롤 수정

### DIFF
--- a/src/components/c-slider/page.styled.ts
+++ b/src/components/c-slider/page.styled.ts
@@ -61,7 +61,7 @@ export const StyledSlider = styled(Slider)`
     top: 42px;
 
     span {
-      width: 100%;
+      width: max-content;
       font-size: 11px;
       font-style: normal;
       font-weight: 400;


### PR DESCRIPTION
## 📑 제목
식당 추천, 리뷰 작성 페이지의 횡스크롤 수정

## 📎 관련 이슈
resolve #(이슈 번호)
  
## 💬 작업 내용
- rc-slider의 .rc-slider-mark의 span width가 너무 크게 잡혀 있어 횡 스크롤이 생겼던 것입니다.
- width를 max-content로 수정했습니다.
 
## 🚧 PR 특이 사항
-없습니다. 

## 🕰 실제 소요 시간
0.2h