### PR TITLE
fix: 회원가입 서버 엔드포인트 변경 반영

### DIFF
--- a/src/apis/register/index.ts
+++ b/src/apis/register/index.ts
@@ -8,7 +8,9 @@ interface PostAccountAuthCodeRes {
 }
 
 interface PostConfirmAuthCodeRes {
-  data: string;
+  data: {
+    authenticationId: number;
+  };
 }
 
 interface PostAccountAuthParams {
@@ -41,6 +43,7 @@ interface PostRegisterUserParams {
     identification: string;
     password: string;
     category: 'email';
+    authenticationId: number;
   };
   agreements: [
     {
@@ -52,7 +55,7 @@ interface PostRegisterUserParams {
 
 interface GetRegisterRepository {
   postAccountAuthCode: ({ identification, type }: PostAccountAuthParams) => Promise<PostAccountAuthCodeRes>;
-  postConfirmAuthCode: ({ historyId, code }: PostConfirmAuthCodeParams) => Promise<PostConfirmAuthCodeParams>;
+  postConfirmAuthCode: ({ historyId, code }: PostConfirmAuthCodeParams) => Promise<PostConfirmAuthCodeRes>;
   postCompanyAuthCode: ({ identification, type }: PostAccountAuthParams) => Promise<PostAccountAuthCodeRes>;
   postRegisterUser: (payload: PostRegisterUserParams) => Promise<any>;
 }
@@ -60,18 +63,18 @@ interface GetRegisterRepository {
 export const getRegisterRepository = (): GetRegisterRepository => {
   return {
     postAccountAuthCode: async ({ identification, type, category }: PostAccountAuthParams) =>
-      await http.post<PostAccountAuthCodeRes, PostAccountAuthParams>('/apis/v1/authentication/account', {
+      await http.post<PostAccountAuthCodeRes, PostAccountAuthParams>('/apis/v1/authentication/public/account', {
         identification,
         type,
         category,
       }),
     postConfirmAuthCode: async ({ historyId, code }: PostConfirmAuthCodeParams) =>
-      await http.post<PostConfirmAuthCodeRes, PostConfirmAuthCodeParams>('/apis/v1/authentication/status/done', {
+      await http.post<PostConfirmAuthCodeRes, PostConfirmAuthCodeParams>('/apis/v1/authentication/public/status/done', {
         historyId,
         code,
       }),
     postCompanyAuthCode: async ({ identification, type }: PostAccountAuthParams) =>
-      await http.post<PostAccountAuthCodeRes, PostAccountAuthParams>('/apis/v1/authentication/company', {
+      await http.post<PostAccountAuthCodeRes, PostAccountAuthParams>('/apis/v1/authentication/public/company', {
         identification,
         type,
       }),

--- a/src/apis/user/getUser.ts
+++ b/src/apis/user/getUser.ts
@@ -25,7 +25,7 @@ export interface UserRes {
 
 export const getUser = async (token?: string) => {
   const res = await http.get<{ data?: UserRes }>(
-    '/apis/v1/user/profile',
+    '/apis/v1/user',
     token
       ? {
           headers: {

--- a/src/app/find-password/components/verify-auth-number/index.tsx
+++ b/src/app/find-password/components/verify-auth-number/index.tsx
@@ -12,9 +12,10 @@ interface Props {
   type: 'register' | 'find-password';
   emailAuthId: number;
   setEmailAuthId?: (value: number) => void;
+  saveAuthId?: (authenticationId: number) => void;
 }
 
-export default function VerifyAuthNumber({ onNext, type, setEmailAuthId, emailAuthId }: Props) {
+export default function VerifyAuthNumber({ onNext, type, setEmailAuthId, emailAuthId, saveAuthId }: Props) {
   const { getValues } = useFormContext();
   const [authNumber, setAuthNumber] = useState('');
 
@@ -24,7 +25,7 @@ export default function VerifyAuthNumber({ onNext, type, setEmailAuthId, emailAu
     category: 'account',
     type: 'retry',
   });
-  const { mutate: confirmAuthCodeMutate } = useConfirmAuthCodeMutate({ onNext, type });
+  const { mutate: confirmAuthCodeMutate } = useConfirmAuthCodeMutate({ onNext, type, saveAuthId });
 
   const handleChangeAuthNumber = (e: ChangeEvent<HTMLInputElement>) => {
     setAuthNumber(e.target.value);

--- a/src/app/sign-up/components/verify-company/index.tsx
+++ b/src/app/sign-up/components/verify-company/index.tsx
@@ -19,7 +19,7 @@ export default function VerifyCompany({ onNext, setCompanyEmailAuthId }: Props) 
     userProperty: {
       companyData: {
         companyName: string;
-        companyEmail: string;
+        identification: string;
       };
     };
   }>();
@@ -32,14 +32,14 @@ export default function VerifyCompany({ onNext, setCompanyEmailAuthId }: Props) 
 
   const onCompanyEmailAuthRequest = () => {
     accountAuthCodeMutate({
-      identification: getValues('userProperty.companyData.companyEmail'),
+      identification: getValues('userProperty.companyData.identification'),
       type: 'email',
       category: 'company',
     });
   };
 
   const buttonDisabledState =
-    getValues('userProperty.companyData.companyEmail')?.length > 0 &&
+    getValues('userProperty.companyData.identification')?.length > 0 &&
     getValues('userProperty.companyData.companyName')?.length > 0;
 
   return (
@@ -64,8 +64,8 @@ export default function VerifyCompany({ onNext, setCompanyEmailAuthId }: Props) 
             label="회사 이메일"
             placeholder="이메일 주소 입력"
             type="text"
-            errorMsg={errors.userProperty?.companyData?.companyEmail ? '이메일 형식이 맞지 않습니다.' : undefined}
-            {...register('userProperty.companyData.companyEmail', { required: false, pattern: /^\S+@\S+$/i })}
+            errorMsg={errors.userProperty?.companyData?.identification ? '이메일 형식이 맞지 않습니다.' : undefined}
+            {...register('userProperty.companyData.identification', { required: false, pattern: /^\S+@\S+$/i })}
           />
         </S.InputContainer>
 

--- a/src/app/sign-up/components/verify-number/index.tsx
+++ b/src/app/sign-up/components/verify-number/index.tsx
@@ -14,13 +14,14 @@ interface Props {
   type: 'register';
   companyEmailAuthId: number;
   setCompanyEmailAuthId: (value: number) => void;
+  saveAuthId?: (authenticationId: number) => void;
 }
 
-export default function VerifyNumber({ onNext, type, companyEmailAuthId, setCompanyEmailAuthId }: Props) {
+export default function VerifyNumber({ onNext, type, companyEmailAuthId, setCompanyEmailAuthId, saveAuthId }: Props) {
   const { getValues } = useFormContext();
   const [authNumber, setAuthNumber] = useState('');
 
-  const { mutate: confirmAuthCodeMutate } = useConfirmAuthCodeMutate({ onNext, type });
+  const { mutate: confirmAuthCodeMutate } = useConfirmAuthCodeMutate({ onNext, type, saveAuthId });
 
   const handleChangeAuthNumber = (e: ChangeEvent<HTMLInputElement>) => {
     setAuthNumber(e.target.value);
@@ -39,7 +40,7 @@ export default function VerifyNumber({ onNext, type, companyEmailAuthId, setComp
 
   const onCompanyEmailAuthRequest = () => {
     accountAuthCodeMutate({
-      identification: getValues('userProperty.companyEmail'),
+      identification: getValues('userProperty.identification'),
       type: 'email',
       category: 'company',
     });
@@ -83,7 +84,7 @@ export default function VerifyNumber({ onNext, type, companyEmailAuthId, setComp
           btnText="다음"
           disabled={authNumber.length === 0 || false}
           onClick={onConfirmAuthCode}
-          type="submit"
+          type="button"
         />
       </S.Wrapper>
     </>

--- a/src/app/sign-up/hooks/query/useConfirmAuthCodeMutate.ts
+++ b/src/app/sign-up/hooks/query/useConfirmAuthCodeMutate.ts
@@ -6,9 +6,10 @@ import { useMutation } from '@tanstack/react-query';
 interface Props {
   onNext: () => void;
   type: 'register' | 'find-password';
+  saveAuthId?: (authenticationId: number) => void;
 }
 
-const useConfirmAuthCodeMutate = ({ onNext, type }: Props) => {
+const useConfirmAuthCodeMutate = ({ onNext, type, saveAuthId }: Props) => {
   const { openModal, closeModal } = useModal();
 
   const authCompleteModal = (type: 'register' | 'find-password') => {
@@ -40,7 +41,10 @@ const useConfirmAuthCodeMutate = ({ onNext, type }: Props) => {
   };
 
   const { mutate } = useMutation(getRegisterRepository().postConfirmAuthCode, {
-    onSuccess: () => authCompleteModal(type),
+    onSuccess: data => {
+      saveAuthId?.(data.data.authenticationId);
+      authCompleteModal(type);
+    },
   });
 
   return { mutate };


### PR DESCRIPTION
## 📑 제목
fix: 회원가입 서버 엔드포인트 변경 반영

## 📎 관련 이슈
resolve #TAS-127
  
## 💬 작업 내용
- /v1/user POST request 값 수정 반영
- /v1/authentication/account, /v1/authentication/status/done 엔드포인트 변경 반영
 
## 🚧 PR 특이 사항
- 회원가입이 되지 않았는데, 회원가입이 완료 되었다고 나오는 문제도 해결이 된 것 같습니다.
기존엔 회사 이메일 인증 후 , onNext 이벤트 호출이 되면서 동시에 form submit 이벤트도 실행이 되어서 해당 에러가 발생한 것 같습니다.
회사 이메일 인증 후, '이메일 인증이 완료되었습니다' 팝업에서 '다음' 버튼을 눌러야 onNext 이벤트(회원가입 request)를 호출하는 것으로 로직 수정을 하니 에러가 재현되지 않았습니다.
- 비밀번호 찾기에서는 기존 엔드포인트를 사용해야 되는데 그 부분은 수정하지 못했습니다.

## 🕰 실제 소요 시간
3h