### PR TITLE
feat: 마이페이지 > 의견보내기 메일 추가, 공지사항 링크 연결, 빈 페이지 route 연결 해제

### DIFF
--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -32,7 +32,7 @@ export default function MyPage() {
             <CMypageMenu
               title="계정"
               items={[
-                { name: '개인정보 관리', hasArrow: true, pathname: '/mypage/user/manage-info' },
+                { name: '개인정보 관리', hasArrow: true, clickEvent: () => push("/mypage/user/manage-info") },
                 { name: '내 리뷰 관리' },
                 { name: '북마크 목록' },
                 { name: '추천 제외 식당 보기' },
@@ -42,14 +42,16 @@ export default function MyPage() {
 
           <CMypageMenu
             title="게시판"
-            items={[{ name: '공지사항' }, { name: '자주 묻는 질문' }, { name: '의견 보내기' }]}
+            items={[{ name: '공지사항', clickEvent: () => window.open("https://tastetionary.notion.site/03ebf00931f44926b889e085cabbd02c?v=5c1337997b384b15a63e6d89a3708ed9&pvs=74") }, { name: '자주 묻는 질문' }, { name: '의견 보내기', 
+          mail: "tastetionary@gmail.com"
+          }]}
           />
 
           <CMypageMenu
             title="약관 및 정책"
             items={[
-              { name: '서비스 이용약관', pathname: '/sign-up?step=terms-of-service' },
-              { name: '개인정보 처리 방침', pathname: '/sign-up?step=privacy-notice' },
+              { name: '서비스 이용약관', clickEvent: () => push('/sign-up?step=terms-of-service') },
+              { name: '개인정보 처리 방침', clickEvent: () => push('/sign-up?step=privacy-notice' ) },
             ]}
           />
         </S.MenuList>

--- a/src/components/c-mypage-menu/index.tsx
+++ b/src/components/c-mypage-menu/index.tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/navigation';
 import * as S from './page.styled';
 
 interface Props {
@@ -6,12 +5,12 @@ interface Props {
   items: {
     name: string;
     hasArrow?: boolean;
-    pathname?: string;
+    clickEvent?: () => void;
+    mail?: string;
   }[];
 }
 
 export default function CMypageMenu({ title, items }: Props) {
-  const router = useRouter();
   return (
     <S.Menu>
       <S.MenuTitle>{title}</S.MenuTitle>
@@ -20,8 +19,10 @@ export default function CMypageMenu({ title, items }: Props) {
         <S.MenuItem
           key={i}
           onClick={() => {
-            router.push(d.pathname as string);
+            if(d.clickEvent) d.clickEvent();
           }}
+          as={d.mail ? "a" : undefined}
+          href={d.mail ? "mailto:tastetionary@gmail.com" : undefined}
         >
           <span>{d.name}</span>
 


### PR DESCRIPTION
## 📑 제목
마이페이지 > 의견보내기 메일 추가, 공지사항 링크 연결, 빈 페이지 route 연결 해제

## 📎 관련 이슈
resolve #TAS-148
  
## 💬 작업 내용
- 마이페이지 > 의견보내기 메일 추가: CMypageMenu props에 mail을 추가해 mail이 있으면 a 태그 변환 후 mailto 기능을 추가했습니다
- 공지사항 링크 연결: CMypageMenu props에 기존에 있던 pathname 을 삭제하고
- 빈 페이지 route 연결 해제: clickEvent가 있어야 이벤트 작동하도록 수정
 
## 🚧 PR 특이 사항
- 없습니다

## 🕰 실제 소요 시간
0.5h