### PR TITLE
fix: 식당 추첨 시 음식 종류 한 개만 선택 가능하도록 수정

### DIFF
--- a/src/app/select-restaurant/page.tsx
+++ b/src/app/select-restaurant/page.tsx
@@ -32,7 +32,7 @@ export default function SelectRestaurant() {
 
       <S.SectionContainer>
         <CSelectSection title="음식 종류">
-          <CSelectCategory data={data?.categories} selectType="restaurant" isDuplicate />
+          <CSelectCategory data={data?.categories} selectType="restaurant" isDuplicate={false} />
         </CSelectSection>
 
         <CSelectSection title="키워드" subtitle="(복수 선택 가능)">

--- a/src/components/c-select-category/index.tsx
+++ b/src/components/c-select-category/index.tsx
@@ -38,13 +38,14 @@ export default function CSelectCategory({ selectType, data, isDuplicate = true }
     <S.MenuContainer>
       {data?.map((m: { id: number; name: string; icon: string }, i: number) => {
         const isSelected = selectedCategory?.includes(m?.name);
+        const isAll = m.id === 0; // 전체
 
         const allCatgoryName = data?.map(m => m.name);
 
         const onMenuItemClick = () => {
           if (selectedCategory?.length > 0 && isSelected) {
             // 이미 선택된 경우
-            if (i === 0) {
+            if (isAll) {
               setSelectedCategory([]);
             } else {
               setSelectedCategory(prev => {
@@ -55,7 +56,7 @@ export default function CSelectCategory({ selectType, data, isDuplicate = true }
             }
           } else {
             // 새롭게 추가하는 경우
-            if (i === 0) {
+            if (isAll) {
               setSelectedCategory(allCatgoryName);
             } else if (isDuplicate) {
               setSelectedCategory(prev => [...prev, m?.name]);


### PR DESCRIPTION
## 📑 제목
식당 추첨 시 음식 종류 한 개만 선택 가능하도록 수정

## 📎 관련 이슈
resolve #TAS-188
  
## 💬 작업 내용
- 식당 추첨 시 음식 종류 한 개만 선택 가능하도록 duplicate 옵션 false로 설정
- 식당 추첨 음식 option 값 서버에서 조정되면 바로 반영가능하도록, 기존에 array의 index 0번으로 구분하던 전체 값을 id가 0이면 전체라고 체크하는 것으로 수정
 
## 🚧 PR 특이 사항
- PR을 볼 때 주의깊게 봐야하거나 말하고 싶은 점  
- 혹은 급하게 PR을 merge해야하는 사유를 적어주세요. 후행 작업 issue number나 백로그도 남겨주시면 좋습니다.

(특이 사항 1)  
(특이 사항 2)  
(특이 사항 3)  

## 🕰 실제 소요 시간
0.1h