### PR TITLE
[TAS-182] 식당 추첨 페이지 상단 문구 삭제

### DIFF
--- a/src/app/select-restaurant/result/page.tsx
+++ b/src/app/select-restaurant/result/page.tsx
@@ -141,7 +141,6 @@ export default function SelectRestaurantResult() {
       <CHeader title="식당 추첨 결과" isBackBtn />
 
       <S.ResultContainer>
-        <S.ResultLabel>조건에 맞는 23,000개의 식당 중에서 오늘 점심은...</S.ResultLabel>
         <S.ResultValue>{restaurantName}</S.ResultValue>
       </S.ResultContainer>
 


### PR DESCRIPTION
## 📑 제목
식당 추첨 페이지 상단 문구 삭제

## 📎 관련 이슈
resolve #TAS-182
  
## 💬 작업 내용
- 상단 '조건에 맞는 n개의 식당 중에서 오늘 점심은..' 문구 삭제 
![image](https://github.com/tastetionary/tastetionary-client/assets/66504333/0ff2da24-1cdb-4a1c-a49c-bfc3d4995a0d)

 
## 🚧 PR 특이 사항
- 없습니다.

## 🕰 실제 소요 시간
- 0.1h