### PR TITLE
fix: 이미지 검색 쿼리에 지역 이름 들어가도록 수정

### DIFF
--- a/src/app/select-restaurant/result/page.tsx
+++ b/src/app/select-restaurant/result/page.tsx
@@ -32,12 +32,18 @@ export default function SelectRestaurantResult() {
 
   useEffect(() => {
     const getImage = async () => {
-      const res = await axios.get(`/search-image-api?query=${restaurantName}`, {
-        headers: {
-          'X-Naver-Client-Id': process.env.NEXT_PUBLIC_NAVER_CLIENT_ID,
-          'X-Naver-Client-Secret': process.env.NEXT_PUBLIC_NAVER_CLIENT_SECRET,
-        },
-      });
+      const needDistrict = !restaurantName?.includes(' ');
+      const district = address?.split(' ')?.[1];
+
+      const res = await axios.get(
+        `/search-image-api?query=${needDistrict && district ? `${district} ${restaurantName}` : restaurantName}`,
+        {
+          headers: {
+            'X-Naver-Client-Id': process.env.NEXT_PUBLIC_NAVER_CLIENT_ID,
+            'X-Naver-Client-Secret': process.env.NEXT_PUBLIC_NAVER_CLIENT_SECRET,
+          },
+        }
+      );
 
       if (res?.data?.total >= 15) {
         setImageUrl([res?.data?.items?.[0]?.link, res?.data?.items?.[1]?.link, res?.data?.items?.[2]?.link]);
@@ -46,10 +52,10 @@ export default function SelectRestaurantResult() {
       }
     };
 
-    if (restaurantName && restaurantName?.length > 0) {
+    if (restaurantName && restaurantName?.length > 0 && address !== '') {
       getImage();
     }
-  }, [restaurant]);
+  }, [restaurant, address]);
 
   useEffect(() => {
     const getAddress = async () => {


### PR DESCRIPTION
## 📑 제목
이미지 검색 쿼리에 지역 이름 들어가도록 수정

## 📎 관련 이슈
resolve #(이슈 번호)
  
## 💬 작업 내용
- 식당 이미지 검색 시 간혹 식당 이름만 검색하면 이상한 이미지가 나오는 경우가 있어 식당 이름에 띄어쓰기가 없는 경우(지역 이름이 없는 경우) 지역명(구/시)를 넣도록 수정
 
## 🚧 PR 특이 사항
- 식당 이름 뒤에 지역(점포)명이 붙는 경우(ex. 스타벅스 여의도R점)는 문제가 없지만 지역명이 없는 경우(ex. 호타루)의 경우 이상한 이미지가 나오는 것으로 확인 되어, 지역명이 없는 경우가 식당 이름에 띄어쓰기(" ")가 없는 것으로 간주하고 작업했습니다.
- 모든 식당 이름을 확인한 것이 아니라 문제가 있는지는 지켜봐야 할 거 같습니다.

## 🕰 실제 소요 시간
0.5h