### PR TITLE
fix: 로딩 이미지 사이즈 수정

### DIFF
--- a/src/app/login/callback/page.tsx
+++ b/src/app/login/callback/page.tsx
@@ -60,8 +60,8 @@ export default function LoginCallback() {
             preserveAspectRatio: '',
           }}
           animationData={Loading}
-          height={200}
-          width={200}
+          height={80}
+          width={80}
         />
       </div>
     </div>

--- a/src/components/Modal/LoadingModal/style.ts
+++ b/src/components/Modal/LoadingModal/style.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const loadingModalContainerVariants = cva(
-  'z-100 sm:max-w-[calc(100vs - 40px)] flex w-full max-w-[120px] flex-col justify-between',
+  'z-100 sm:max-w-[calc(100vs - 40px)] flex w-full max-w-[80px] flex-col justify-between',
   {
     variants: {
       visibility: {


### PR DESCRIPTION
## 📑 제목
로딩 애니메이션 사이즈 변경

## 📎 관련 이슈
resolve #TAS-240

https://www.notion.so/13f1d0242c2580418aeacbfe534da02d?pvs=4
  
## 💬 작업 내용
- 로딩 애니메이션 사이즈 120 -> 80 변경
 
<img width="136" alt="image" src="https://github.com/user-attachments/assets/158c840d-8f9a-4dc7-98e0-cab71c67b48a">

## 🚧 PR 특이 사항
- 메뉴/식당 선택 시 로딩 애니메이션 크기도 80으로 변경 됩니다! (전에 아름님이 80으로 바꿔달라고 하셨어서 문제 없을 거 같아요)

## 🕰 실제 소요 시간
0.1h