### PR TITLE
이메일로 로그인 화면 변경 사항

### DIFF
--- a/src/app/find-password/components/verify-auth-number/index.tsx
+++ b/src/app/find-password/components/verify-auth-number/index.tsx
@@ -1,5 +1,6 @@
 import useAccountAuthCodeMutate from '@/app/sign-up/hooks/query/useAccountAuthCodeMutate';
 import useConfirmAuthCodeMutate from '@/app/sign-up/hooks/query/useConfirmAuthCodeMutate';
+import BottomButtonContainer from '@/components/Button/BottomButtonContainer';
 import DefaultButton from '@/components/Button/DefaultButton';
 import CHeader from '@/components/c-header';
 // import Header from '@/components/Header';
@@ -44,13 +45,14 @@ export default function VerifyAuthNumber({ onNext, type, setEmailAuthId, emailAu
   return (
     <>
       <CHeader title="회원가입" />
-      <div className="mx-8 mt-20">
+
+      <div className="mx-8 mt-xl">
         <header>
-          <h1 className="!font-pretendard text-xl font-bold leading-8">
+          <h1 className="title2 font-bold">
             1시간 이내로 이메일로 발송된 <br />
             인증 코드를 입력해 주세요. 🔒
           </h1>
-          <p className="mt-3 !font-pretendard leading-5 text-neutral-bg80">
+          <p className="body2 mt-3 text-neutral-bg80">
             인증 코드를 받지 못하신 경우, 스팸메일함을 확인하거나 <br />
             하단의 재전송 버튼을 통해 인증 코드를 다시 받으세요.
           </p>
@@ -70,23 +72,25 @@ export default function VerifyAuthNumber({ onNext, type, setEmailAuthId, emailAu
         </section>
       </div>
 
-      <footer className="fixed bottom-[30px] w-[360px] px-25 pb-10 pt-5 mobile:w-full">
-        <div className="flex justify-center gap-2">
-          <p className="!font-pretendard text-sm text-neutral-bg80">인증 코드를 받지 못하셨나요?</p>
-          <DefaultButton bgColor="gray" customStyle="px-[12px] py-[4px]" onClick={onEmailAuthRequest}>
-            <span className="!font-pretendard">메일 재전송</span>
+      <BottomButtonContainer>
+        <footer className="w-full">
+          <div className="flex justify-center gap-2">
+            <p className="!font-pretendard text-sm text-neutral-bg80">인증 코드를 받지 못하셨나요?</p>
+            <DefaultButton bgColor="gray" customStyle="px-[12px] py-[4px]" onClick={onEmailAuthRequest}>
+              <span className="!font-pretendard">메일 재전송</span>
+            </DefaultButton>
+          </div>
+          <DefaultButton
+            bgColor="yellow"
+            customStyle="flex w-full py-[12px] px-[16px] mt-6"
+            disabled={authNumber.length === 0 || false}
+            onClick={onConfirmAuthCode}
+            type="button"
+          >
+            <span className="!font-pretendard text-white">다음</span>
           </DefaultButton>
-        </div>
-        <DefaultButton
-          bgColor="yellow"
-          customStyle="flex w-full py-[12px] px-[16px] mt-6"
-          disabled={authNumber.length === 0 || false}
-          onClick={onConfirmAuthCode}
-          type="button"
-        >
-          <span className="!font-pretendard text-white">다음</span>
-        </DefaultButton>
-      </footer>
+        </footer>
+      </BottomButtonContainer>
     </>
   );
 }

--- a/src/app/login/email/page.tsx
+++ b/src/app/login/email/page.tsx
@@ -42,8 +42,10 @@ export default function EmailLogin() {
     <>
       <CHeader title="이메일 로그인" />
 
-      <div className="mt-xxxl flex w-full flex-col gap-xl px-xl">
-        <h1 className="title2 break-keep font-bold ">이메일로 로그인 ✉</h1>
+      <div className="mt-xl flex w-full flex-col gap-xl px-xl">
+        <h1 className="title2 break-keep font-bold ">
+          이메일로 로그인 <span>✉️</span>
+        </h1>
 
         <form className="flex flex-col gap-md" onSubmit={handleSubmit(onSubmitHandler)}>
           <TextInput

--- a/src/app/login/email/page.tsx
+++ b/src/app/login/email/page.tsx
@@ -77,7 +77,7 @@ export default function EmailLogin() {
             })}
           />
 
-          <DefaultButton bgColor="yellow" customStyle="h-46 mt-xl" disabled={!isValid}>
+          <DefaultButton bgColor="yellow" customStyle="h-46 mt-xs" disabled={!isValid}>
             <span className="body1 text-white">로그인</span>
           </DefaultButton>
         </form>

--- a/src/app/sign-up/components/complete/index.tsx
+++ b/src/app/sign-up/components/complete/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import COMPLETE from '@/assets/logo/complete.svg';
+import BottomButtonContainer from '@/components/Button/BottomButtonContainer';
 import DefaultButton from '@/components/Button/DefaultButton';
 import CHeader from '@/components/c-header';
 import { useRouter } from 'next/navigation';
@@ -14,21 +15,25 @@ export default function SignUpComplete() {
       <CHeader title="회원가입 완료" />
       <S.Wrapper>
         <COMPLETE />
-        <div className="mt-5 !font-pretendard text-xl font-bold leading-relaxed">회원가입이 완료되었습니다.</div>
-        <p className="my-[15px] mb-[100px] !font-pretendard text-sm font-normal leading-[170%] text-neutral-bg60">
+        <div className="title2 mt-5 font-bold">회원가입이 완료되었습니다.</div>
+        <p className="body2 my-[15px] mb-[100px] text-neutral-bg60">
           지역 변경을 원하신다면{' '}
-          <span className="!font-pretendard text-sm font-bold text-neutral-bg60">개인정보 관리 {'>'} 지역 변경</span>{' '}
-          <br />
-          또는 <span className="!font-pretendard text-sm font-bold text-neutral-bg60">메인화면</span>에서 위치를
-          변경해주세요.
+          <span className="body2 font-bold text-neutral-bg60">개인정보 관리 {'>'} 지역 변경</span> <br />
+          또는 <span className="body2 font-bold text-neutral-bg60">메인화면</span>에서 위치를 변경해주세요.
         </p>
       </S.Wrapper>
 
-      <footer className="fixed bottom-[30px] w-[360px] px-25 pb-10 pt-5 mobile:w-full">
-        <DefaultButton bgColor="orange" customStyle="flex w-full py-[12px] px-[16px]" onClick={() => router.push('/')}>
-          <span className="!font-pretendard text-white">메인 화면으로 이동</span>
-        </DefaultButton>
-      </footer>
+      <BottomButtonContainer>
+        <footer className="w-full">
+          <DefaultButton
+            bgColor="orange"
+            customStyle="flex w-full py-[12px] px-[16px]"
+            onClick={() => router.push('/')}
+          >
+            <span className="!font-pretendard text-white">메인 화면으로 이동</span>
+          </DefaultButton>
+        </footer>
+      </BottomButtonContainer>
     </>
   );
 }

--- a/src/app/sign-up/components/email-form/index.tsx
+++ b/src/app/sign-up/components/email-form/index.tsx
@@ -1,5 +1,6 @@
 import DefaultButton from '@/components/Button/DefaultButton';
 // import Header from '@/components/Header';
+import BottomButtonContainer from '@/components/Button/BottomButtonContainer';
 import CHeader from '@/components/c-header';
 import TextInput from '@/components/Input/TextInput';
 import { emailRegex } from '@/constants';
@@ -31,12 +32,12 @@ export default function EmailForm({ onNext, setEmailAuthId }: Props) {
   return (
     <>
       <CHeader title="회원가입" />
-      <div className="mx-8 my-20">
+      <div className="mx-xl mb-20 mt-xl">
         <header>
-          <h1 className="!font-pretendard text-xl font-bold leading-8">
+          <h1 className="title2 font-bold">
             아이디로 사용할 <br /> 이메일 주소를 입력해 주세요. ✍️
           </h1>
-          <p className="mt-3 !font-pretendard text-sm leading-5 text-neutral-bg80">
+          <p className="body2 mt-3 text-neutral-bg80">
             입력하신 이메일 주소는 로그인과 비밀번호 재설정, 중요한 소식 전달에 사용됩니다. 정확한 이메일 주소를 입력해
             주세요.
           </p>
@@ -53,7 +54,7 @@ export default function EmailForm({ onNext, setEmailAuthId }: Props) {
         </section>
       </div>
 
-      <footer className="fixed bottom-[30px] w-[360px] px-25 pb-10 pt-5 mobile:w-full">
+      <BottomButtonContainer>
         <DefaultButton
           bgColor="yellow"
           customStyle="flex w-full py-[12px] px-[16px]"
@@ -63,7 +64,7 @@ export default function EmailForm({ onNext, setEmailAuthId }: Props) {
         >
           <span className="font-pretendard text-white">다음</span>
         </DefaultButton>
-      </footer>
+      </BottomButtonContainer>
     </>
   );
 }

--- a/src/app/sign-up/components/region-setting/index.tsx
+++ b/src/app/sign-up/components/region-setting/index.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import BottomButtonContainer from '@/components/Button/BottomButtonContainer';
 import DefaultButton from '@/components/Button/DefaultButton';
 import TextInput from '@/components/Input/TextInput';
 import CHeader from '@/components/c-header';
@@ -87,11 +88,11 @@ export default function RegionSetting({ onNext, category = 'dining_area' }: Prop
 
       <S.Wrapper>
         <header>
-          <h1 className="!font-pretendard text-xl font-bold leading-8">
+          <h1 className="title2 font-bold">
             지역을 설정하면 <br />
             근처에 있는 식당들을 추천받을 수 있어요. 🍽️
           </h1>
-          <p className="mt-3 !font-pretendard leading-5 text-neutral-bg80">
+          <p className="body2 mt-3 text-neutral-bg80">
             주소를 자세히 설정하면 근처의 식당들을 더 구체적으로 추천해드릴 수 있어요.
           </p>
         </header>
@@ -128,17 +129,19 @@ export default function RegionSetting({ onNext, category = 'dining_area' }: Prop
       </S.Wrapper>
 
       {!openPostCode && (
-        <footer className="fixed bottom-[30px] w-[360px] px-25 pb-10 pt-5 mobile:w-full">
-          <DefaultButton
-            bgColor="yellow"
-            customStyle="flex w-full py-[12px] px-[16px] mt-6"
-            disabled={address === ''}
-            onClick={onNext}
-            type="submit"
-          >
-            <span className="!font-pretendard text-white">다음</span>
-          </DefaultButton>
-        </footer>
+        <BottomButtonContainer>
+          <footer className="w-full">
+            <DefaultButton
+              bgColor="yellow"
+              customStyle="flex w-full py-[12px] px-[16px] mt-6"
+              disabled={address === ''}
+              onClick={onNext}
+              type="submit"
+            >
+              <span className="!font-pretendard text-white">다음</span>
+            </DefaultButton>
+          </footer>
+        </BottomButtonContainer>
       )}
     </>
   );

--- a/src/app/sign-up/components/terms/index.tsx
+++ b/src/app/sign-up/components/terms/index.tsx
@@ -1,3 +1,4 @@
+import BottomButtonContainer from '@/components/Button/BottomButtonContainer';
 import DefaultButton from '@/components/Button/DefaultButton';
 import CheckBox2 from '@/components/CheckBox/CheckBox2';
 import CHeader from '@/components/c-header';
@@ -29,12 +30,14 @@ export default function Terms({ onNext }: Props) {
   return (
     <>
       <CHeader title="회원 가입" />
-      <div className="mx-8 my-20">
+      <div className="mx-8 mb-20 mt-xl">
         <header>
-          <h1 className="!font-pretendard font-bold leading-8">
-            안녕하세요 👋 <br /> 맛셔너리 이용을 위해 아래 약관에 동의해주세요.
+          <h1 className="title2 font-bold">
+            안녕하세요 👋 <br /> 맛셔너리 이용을 위해
+            <br />
+            아래 약관에 동의해주세요.
           </h1>
-          <p className="mt-3 !font-pretendard text-sm leading-5 text-neutral-bg80">
+          <p className="body2 mt-3 text-neutral-bg80">
             서비스 이용을 위해 동의가 필요합니다. <br />
             정책 및 약관을 확인하신 후, 회원가입을 진행해주세요.
           </p>
@@ -92,7 +95,7 @@ export default function Terms({ onNext }: Props) {
         </section>
       </div>
 
-      <footer className="fixed bottom-[30px] w-[360px] px-25 pb-10 pt-5 mobile:w-full">
+      <BottomButtonContainer>
         <DefaultButton
           bgColor="yellow"
           customStyle="flex w-full py-[12px] px-[16px]"
@@ -102,7 +105,7 @@ export default function Terms({ onNext }: Props) {
         >
           <span className="font-pretendard text-white">다음</span>
         </DefaultButton>
-      </footer>
+      </BottomButtonContainer>
     </>
   );
 }

--- a/src/app/sign-up/components/user-info-form/index.tsx
+++ b/src/app/sign-up/components/user-info-form/index.tsx
@@ -98,7 +98,7 @@ export default function UserInfoForm({ onNext }: Props) {
               bgColor="yellow"
               customStyle="bottom-0 absolute h-48 right-0 px-[16px] py-[12px] text-xs"
               onClick={handleValidateNickname}
-              disabled={nickname.length === 0}
+              disabled={!nickname || nickname?.length === 0}
               type="button"
             >
               <span className="!font-pretendard text-white">중복 확인</span>

--- a/src/app/sign-up/components/user-info-form/index.tsx
+++ b/src/app/sign-up/components/user-info-form/index.tsx
@@ -1,3 +1,4 @@
+import BottomButtonContainer from '@/components/Button/BottomButtonContainer';
 import DefaultButton from '@/components/Button/DefaultButton';
 import CHeader from '@/components/c-header';
 import TextInput from '@/components/Input/TextInput';
@@ -25,6 +26,7 @@ export default function UserInfoForm({ onNext }: Props) {
   }>();
 
   const accountEmail = getValues('account.identification');
+  const nickname = getValues('nickname');
 
   // 이메일 주소와 , emailAuthId값을 전달받아서 요청에 보내야함!
   const { mutate: accountAuthCodeMutate } = useAccountAuthCodeMutate({
@@ -40,20 +42,20 @@ export default function UserInfoForm({ onNext }: Props) {
   };
 
   const handleValidateNickname = () => {
-    validateNicknameMutate({ nickname: getValues('nickname') });
+    validateNicknameMutate({ nickname });
   };
 
   return (
     <>
       <CHeader title="회원가입" />
 
-      <div className="mx-8 my-20">
+      <div className="mx-xl mb-40 mt-xl">
         <header>
-          <h1 className="!font-pretendard text-xl font-bold leading-8">
+          <h1 className="title2 font-bold">
             원활한 서비스 이용을 위해 <br />
             아래 회원 정보를 입력해 주세요. ✍️
           </h1>
-          <p className="mt-3 !font-pretendard leading-5 text-neutral-bg80">
+          <p className="body2 mt-3 text-neutral-bg80">
             회원 정보는 개인화된 추천과 원활한 서비스 제공을 위해 사용되며, <br /> 안전하게 보호됩니다.
           </p>
         </header>
@@ -96,6 +98,7 @@ export default function UserInfoForm({ onNext }: Props) {
               bgColor="yellow"
               customStyle="bottom-0 absolute h-48 right-0 px-[16px] py-[12px] text-xs"
               onClick={handleValidateNickname}
+              disabled={nickname.length === 0}
               type="button"
             >
               <span className="!font-pretendard text-white">중복 확인</span>
@@ -103,62 +106,26 @@ export default function UserInfoForm({ onNext }: Props) {
           </div>
         </section>
       </div>
-      <footer className="fixed bottom-[30px] w-[360px] px-25 pb-10 pt-5 mobile:w-full">
-        <div className="flex justify-center gap-2">
-          <p className="!font-pretendard text-sm text-neutral-bg80">인증 코드를 받지 못하셨나요?</p>
-          <DefaultButton bgColor="gray" customStyle="px-[12px] py-[4px]" onClick={onEmailAuthRequest}>
-            <span className="!font-pretendard">메일 재전송</span>
+
+      <BottomButtonContainer>
+        <footer className="w-full">
+          <div className="flex justify-center gap-2">
+            <p className="!font-pretendard text-sm text-neutral-bg80">인증 코드를 받지 못하셨나요?</p>
+            <DefaultButton bgColor="gray" customStyle="px-[12px] py-[4px]" onClick={onEmailAuthRequest}>
+              <span className="!font-pretendard">메일 재전송</span>
+            </DefaultButton>
+          </div>
+          <DefaultButton
+            bgColor="yellow"
+            customStyle="flex w-full py-[12px] px-[16px] mt-6"
+            disabled={!isDirty || !isValid}
+            onClick={onNext}
+            type="button"
+          >
+            <span className="!font-pretendard text-white">다음</span>
           </DefaultButton>
-        </div>
-        <DefaultButton
-          bgColor="yellow"
-          customStyle="flex w-full py-[12px] px-[16px] mt-6"
-          disabled={!isDirty || !isValid}
-          onClick={onNext}
-          type="button"
-        >
-          <span className="!font-pretendard text-white">다음</span>
-        </DefaultButton>
-      </footer>
-
-      {/* <S.Wrapper>
-        <S.Title>회원 정보를 입력해주세요.</S.Title>
-
-        <S.MainContainer>
-          <TextInput
-            label="이메일 주소"
-            placeholder="이메일 주소를 입력해주세요."
-            type="text"
-            value={getValues('account.identification')}
-            disabled
-          />
-          <TextInput
-            label="비밀번호"
-            placeholder="영문, 숫자, 특수문자를 조합하여 8자 이상"
-            type="password"
-            errorMsg={errors.account?.password ? '영문, 숫자, 특수문자를 조합하여 8자 이상 입력해주세요.' : undefined}
-            {...register('account.password', {
-              required: '비밀번호를 입력해주세요',
-              pattern: /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@#$%^&+=!?]).{8,}$/,
-            })}
-          />
-          <TextInput
-            label="비밀번호 확인"
-            placeholder="비밀번호 재입력"
-            type="password"
-            errorMsg={errors.account?.passwordConfirm ? '비밀번호가 일치하지 않습니다.' : undefined}
-            {...register('account.passwordConfirm', {
-              required: true,
-              pattern: /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@#$%^&+=!?]).{8,}$/,
-              validate: value => getValues('account.password') === value || '비밀번호가 일치하지 않습니다.',
-            })}
-          />
-        </S.MainContainer>
-
-        <S.NextButtonWrapper>
-          <MainButton btnText="다음" disabled={!isDirty || !isValid} type="button" onClick={onNext} />
-        </S.NextButtonWrapper>
-      </S.Wrapper> */}
+        </footer>
+      </BottomButtonContainer>
     </>
   );
 }


### PR DESCRIPTION
## 📑 제목
이메일로 로그인 화면 변경 사항

## 📎 관련 이슈
resolve #Tas-241

https://www.notion.so/13f1d0242c258010b23cfdeff5517c09?pvs=4
  
## 💬 작업 내용
- 이메일 이모지 표시
- 상단 여백 32px로 수정
- 회원가입 단계 title: title2 스타일 적용, desc: body2 스타일 적용, 버튼 영역: `<BottomButtonContainer>` 사용해 스타일 값 수정
- 비밀번호와 로그인 버튼 사이 간격 24px로 수정
- 회원가입 과정의 user-info 단계의 닉네임 '중복 확인' 버튼에서 disabled이 되지 않아 nickname 값이 없는데도 버튼을 클릭할 수 있어서 disabled 조건을 추가함
<img width="347" alt="image" src="https://github.com/user-attachments/assets/d951ab78-7d0f-45ab-acc8-e4dc51bc0e6b">
<img width="346" alt="image" src="https://github.com/user-attachments/assets/971e70f5-bf45-46ed-86a9-bb10266b0281">
<img width="345" alt="image" src="https://github.com/user-attachments/assets/5c58c3d6-308f-408d-85d6-806fc3ad7121">
<img width="343" alt="image" src="https://github.com/user-attachments/assets/6e60219d-a75b-48b5-952d-b2d41f87f2c8">
<img width="346" alt="image" src="https://github.com/user-attachments/assets/dc81cd00-c100-48ba-9781-d64256c26af5">
<img width="346" alt="image" src="https://github.com/user-attachments/assets/9b07a55d-12d5-47ef-b1b5-71756128fe2d">
<img width="345" alt="image" src="https://github.com/user-attachments/assets/6d0ff4d9-2080-4817-b830-c16b7b2fd25f">

 
## 🚧 PR 특이 사항
- TAS-243의 타이틀 텍스트 수정 부분도 반영 되었습니다!
https://www.notion.so/13f1d0242c2580e590bbd5713aa47b4e?pvs=4#13f1d0242c25802aae29d7960857ae1c

## 🕰 실제 소요 시간
0.5h