### PR TITLE
feat: 로그아웃 성공 로직 수정

### DIFF
--- a/src/app/login/hooks/useLogoutMutate.tsx
+++ b/src/app/login/hooks/useLogoutMutate.tsx
@@ -1,25 +1,35 @@
 import authRepository from '@/apis/auth';
+import useToken from '@/hooks/useToken';
 import * as Sentry from '@sentry/nextjs';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
-import { destroyCookie, parseCookies } from 'nookies';
+import { destroyCookie } from 'nookies';
+import { useEffect, useState } from 'react';
 
 const useLogoutMutate = () => {
   const queryClient = useQueryClient();
   const { push } = useRouter();
-  const cookies = parseCookies();
+  const { token } = useToken();
+
+  const [isDestroied, setIsDestroied] = useState(false);
+
+  useEffect(() => {
+    if (!isDestroied || token) {
+      return;
+    }
+
+    queryClient.clear();
+    push('/');
+    setIsDestroied(false);
+  }, [token, isDestroied]);
 
   return useMutation({
     mutationFn: authRepository().postLogout,
     onSuccess: () => {
       Sentry.configureScope(scope => scope.clear());
 
+      setIsDestroied(true);
       destroyCookie(null, 'token');
-
-      if (!cookies.token) {
-        queryClient.clear();
-        push('/');
-      }
     },
   });
 };


### PR DESCRIPTION
## 📑 제목
로그아웃 성공 로직 수정

## 📎 관련 이슈
resolve #(이슈 번호)
  
## 💬 작업 내용
- 원인:  destroyCookie 이후 onsuccess 콜백 내에서 실제 token 값은 사라지지 않았는데, queryclient 값을 날리는 이슈 -> get /user 을 보내 에러 발생
- 해결 방법: token 값을 useeffect로 받아 값이 없으면, queryclient 값을 지우고 홈으로 보낸다 (queryclient 지우는 타이밍을 조금 더 안전하게 수정함)
 
## 🚧 PR 특이 사항
- useEffect 사용을 지양하고 싶은데.. 다른 방법이 있다면 같이 고민을 하면 좋을 것 같습니다 

## 🕰 실제 소요 시간
0.25h